### PR TITLE
フロント購入完了画面 / タイトルを動的に対応 / CSS切り出し

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,144 +13,118 @@
  *= require_tree .
  *= require_self
  */
-@import "bootstrap";
+ @import "bootstrap";
 
-/* header */
-header {
-  background-color: gold;
-}
-
-header .container {
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.hlogo:link,
-.hlogo:visited,
-.hlogo:hover,
-.hmenu:link,
-.hmenu:visited,
-.hmenu:hover,
-.username:link,
-.username:visited,
-.username:hover {
-  color: black;
-  text-decoration: none;
-}
-
-@media screen and (min-width: 769px) {
-
-  /* main */
-  main {
-    margin: 80px 0;
-  }
-
-  .top_inner {
-    padding-top: 160px;
-  }
-
-  /* header */
-  .hmenu {
-    margin-right: 20px;
-  }
-
-  .username {
-    padding-right: 22px;
-  }
-}
-
-/* footer */
-footer .container {
-  display: flex;
-  justify-content: space-between;
-}
-
-footer {
-  background-color: gold;
-}
-
-.flogo:link,
-.flogo:visited,
-.flogo:hover {
-  color: black;
-  text-decoration: none;
-}
-
-/* レスポンシブ */
-@media screen and (max-width: 768px) {
-
-  /* header */
-  .navbar {
-    padding: .25rem .5rem !important;
-  }
-
-  header .container {
-    padding-right: 0px;
-    padding-left: 0px;
-  }
-
-  .display-block {
-    display: block !important;
-  }
-
-  .navbar {
-    padding: .25rem .5rem;
-  }
-
-  .nav-menu {
-    margin: auto;
-  }
-
-  .nav-item {
-    margin: auto;
-  }
-
-  .hlogo {
-    font-size: 1rem;
-  }
-
-  .hmenu {
-    font-size: 0.65rem;
-  }
-
-  .navmenu {
-    width: 100%;
-    margin: .2rem 0 .2rem 0;
-  }
-
-  .username {
-    font-size: .8rem;
-    padding: .4rem .5rem 0 0;
-  }
-
-  /* main */
-  main {
-    margin: 5rem 0;
-  }
-
-  .top_inner {
-    padding-top: 6rem;
-  }
-
-  .title {
-    font-size: 1.6rem
-  }
-
-  .title_text {
-    font-size: .9rem
-  }
-
-  /* footer */
-  footer .container {
-    padding-right: 8px;
-    padding-left: 8px;
-  }
-
-  .flogo {
-    font-size: 0.5rem;
-  }
-
-  .copyright {
-    font-size: 0.5rem;
-  }
-}
+ /* header */
+ header {
+   background-color: gold;
+ }
+ 
+ header .container {
+   padding-left: 0;
+   padding-right: 0;
+ }
+ 
+ .hlogo:link,
+ .hlogo:visited,
+ .hlogo:hover,
+ .hmenu:link,
+ .hmenu:visited,
+ .hmenu:hover,
+ .username:link,
+ .username:visited,
+ .username:hover {
+   color: black;
+   text-decoration: none;
+ }
+ 
+ @media screen and (min-width: 769px) {
+ 
+   /* header */
+   .hmenu {
+     margin-right: 20px;
+   }
+ 
+   .username {
+     padding-right: 22px;
+   }
+ }
+ 
+ /* footer */
+ footer .container {
+   display: flex;
+   justify-content: space-between;
+ }
+ 
+ footer {
+   background-color: gold;
+ }
+ 
+ .flogo:link,
+ .flogo:visited,
+ .flogo:hover {
+   color: black;
+   text-decoration: none;
+ }
+ 
+ /* レスポンシブ */
+ @media screen and (max-width: 768px) {
+ 
+   /* header */
+   .navbar {
+     padding: .25rem .5rem !important;
+   }
+ 
+   header .container {
+     padding-right: 0px;
+     padding-left: 0px;
+   }
+ 
+   .display-block {
+     display: block !important;
+   }
+ 
+   .navbar {
+     padding: .25rem .5rem;
+   }
+ 
+   .nav-menu {
+     margin: auto;
+   }
+ 
+   .nav-item {
+     margin: auto;
+   }
+ 
+   .hlogo {
+     font-size: 1rem;
+   }
+ 
+   .hmenu {
+     font-size: 0.65rem;
+   }
+ 
+   .navmenu {
+     width: 100%;
+     margin: .2rem 0 .2rem 0;
+   }
+ 
+   .username {
+     font-size: .8rem;
+     padding: .4rem .5rem 0 0;
+   }
+ 
+   /* footer */
+   footer .container {
+     padding-right: 8px;
+     padding-left: 8px;
+   }
+ 
+   .flogo {
+     font-size: 0.5rem;
+   }
+ 
+   .copyright {
+     font-size: 0.5rem;
+   }
+ }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,0 +1,470 @@
+/* ユーザー情報修正画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  main .container {
+    width: 600px;
+    margin-top: 40px;
+    margin-bottom: 50px;
+  }
+  #userinfo .form-control {
+    width: 100%;
+  }
+  #userinfo label {
+    justify-content: flex-start !important;
+    display: block;
+  }
+  .fixbtn {
+    margin-right: 150px;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .text-right {
+    text-align: left !important;
+  }
+  #userinfo .form-control {
+    width: 100%;
+    display: inline;
+  }
+  #name.col-3 {
+    max-width: 100%;
+  }
+  #lname.col-3, #fname.col-3 {
+    max-width: 100%;
+  }
+  #userinfo .mt-4 {
+    margin-top: 10px !important;
+  }
+  .fixbtn {
+    margin-right: 5rem;
+  }
+}
+
+
+/* ユーザー登録画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 80px 0;
+  }
+  main .container {
+    width: 540px;
+    margin-top: 40px;
+    margin-bottom: 50px;
+  }
+  input.form-control.lname, input.form-control.fname {
+    width: 216px;
+  }
+  input.form-control.mailform, input.form-control.telform {
+    width: 458px;
+  }
+  #address label {
+    justify-content: flex-start !important;
+  }
+  #address .form-control {
+    width: 100%;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 4.5rem 0;
+  }
+  .text-center {
+    font-size: 1.4rem;
+  }
+  .mailform {
+    width: 14.8rem;
+  }
+  .telform {
+    width: 14.8rem;
+  }
+  .info {
+    font-size: 1rem;
+  }
+}
+
+
+/* ログイン画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 80px 0;
+  }
+}
+.form-signin {
+  width: 100%;
+  max-width: 330px;
+  padding: 15px;
+  margin: auto;
+  font-weight: 400;
+}
+.form-signin .form-control {
+  position: relative;
+  box-sizing: border-box;
+  height: 80%;
+  padding: 10px;
+  font-size: 16px;
+}
+.form-signin .form-control:focus {
+  z-index: 2;
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 1rem 0;
+  }
+}
+
+
+/* 商品検索画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: .2rem 0 .2rem 0;
+  }
+  .username {
+    font-size: .8rem;
+    padding: .4rem .5rem 0 0;
+  }
+}
+
+
+/* 商品詳細画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: .2rem 0 .2rem 0;
+  }
+  .username {
+    font-size: .8rem;
+    padding: .4rem .5rem 0 0;
+  }
+}
+
+
+/* カート内商品一覧画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+
+/* カート内商品一覧 */
+.card {
+  border: 1px solid black;
+  border-radius: 25px;
+  margin-bottom: 60px;
+}
+.table-border {
+  border-top: 1px solid black;
+}
+.remarks {
+  text-align: left;
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: .2rem 0 .2rem 0;
+  }
+  .username {
+    font-size: .8rem;
+    padding: .4rem .5rem 0 0;
+  }
+
+
+  /* カート内商品一覧 */
+  .table {
+    width: 95%;
+  }
+  .table .thead {
+    display: none;
+  }
+  .table tr {
+    width: 100%;
+  }
+  .table td {
+    display: block;
+    text-align: right;
+    width: 100%;
+  }
+  .table td:before {
+    content: attr(data-label);
+    float: left;
+    font-weight: bold;
+    margin-right: 10px;
+  }
+  .table tr .total {
+    font-weight: bold;
+    margin-right: 10px;
+  }
+  .table-border-responsive {
+    border-top: 1px solid black;
+  }
+  .btn {
+    margin-bottom: 30px;
+  }
+}
+
+
+/* 注文詳細画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+
+/* 注文詳細画面 */
+.card {
+  border: 1px solid black;
+  border-radius: 25px;
+}
+
+.table-border {
+  border-top: 1px solid black;
+}
+
+.remarks {
+  text-align: left;
+}
+
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: .2rem 0 .2rem 0;
+  }
+  .username {
+    font-size: .8rem;
+    padding: .4rem .5rem 0 0;
+  }
+
+
+  /* 注文詳細画面 */
+  .table {
+    width: 95%;
+  }
+  .table .thead {
+    display: none;
+  }
+  .table tr {
+    width: 100%;
+  }
+  .table td {
+    display: block;
+    text-align: right;
+    width: 100%;
+  }
+  .table td:before {
+    content: attr(data-label);
+    float: left;
+    font-weight: bold;
+    margin-right: 10px;
+  }
+  .table tr .total {
+    font-weight: bold;
+    margin-right: 10px;
+  }
+  .table-border-responsive {
+    border-top: 1px solid black;
+  }
+}
+
+
+/* 注文履歴画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+
+/* 詳細ボタン */
+td.button {
+  border: none;
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: 0.2rem 0 0.2rem 0;
+  }
+  .username {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.5rem 0 0;
+  }
+  .table {
+    width: 95%;
+  }
+  .table .thead {
+    display: none;
+  }
+  .table tr {
+    width: 100%;
+  }
+  .table td {
+    display: block;
+    text-align: right;
+    width: 100%;
+  }
+  .table td:before {
+    content: attr(data-label);
+    float: left;
+    font-weight: bold;
+    margin-right: 10px;
+  }
+  td.button {
+    text-align: center;
+    margin-bottom: 50px;
+  }
+}
+
+
+/* ユーザー情報画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  .hmenu {
+    margin-right: 20px;
+  }
+  .username {
+    padding-right: 22px;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .navmenu {
+    width: 100%;
+    margin: .2rem 0 .2rem 0;
+  }
+  .username {
+    font-size: .8rem;
+    padding: .4rem .5rem 0 0;
+  }
+}
+
+
+/* ユーザー情報修正画面 */
+@media screen and (min-width: 769px) {
+  main {
+    margin: 106px 0;
+  }
+  main .container {
+    width: 600px;
+    margin-top: 40px;
+    margin-bottom: 50px;
+  }
+  #userinfo .form-control {
+    width: 100%;
+  }
+  #userinfo label {
+    justify-content: flex-start !important;
+    display: block;
+  }
+  .fixbtn {
+    margin-right: 150px;
+  }
+  
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+  main {
+    margin: 5.7rem 0;
+  }
+  .text-right {
+    text-align: left !important;
+  }
+  #userinfo .form-control {
+    width: 100%;
+    display: inline;
+  }
+  #name.col-3 {
+    max-width: 100%;
+  }
+  #lname.col-3, #fname.col-3 {
+    max-width: 100%;
+  }
+  #userinfo .mt-4 {
+    margin-top: 10px !important;
+  }
+  .fixbtn {
+    margin-right: 5rem;
+  }
+}

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -1,3 +1,28 @@
-// Place all the styles related to the StaticPages controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+@media screen and (min-width: 769px) {
+  main { margin: 80px 0; }
+  
+  .top_inner {
+    padding-top: 160px;
+  }
+}
+
+/* レスポンシブ */
+@media screen and (max-width: 768px) {
+
+/* main */
+main {
+  margin: 5rem 0;
+  }
+
+.top_inner {
+  padding-top: 6rem;
+  }
+
+.title {
+  font-size: 1.6rem
+  }
+
+.title_text {
+  font-size: .9rem
+  }
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,7 @@ class StaticPagesController < ApplicationController
   def home
     @login_flag = false
   end
+
+  def purchase_completed
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def full_title(page_title = "")
+    base_title = "探求学園Rails専攻"
+    if page_title.empty?
+      base_title
+    else
+      page_title + " | " + base_title
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>探求学園Rails専攻</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/views/static_pages/purchase_completed.html.erb
+++ b/app/views/static_pages/purchase_completed.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+
+  <div class="top_inner text-center">
+    <h1 class="title font-weight-bold mb-5">購入完了しました</h1>
+    <p class="title_text">ご購入ありがとうございます！</p>
+    <%# 注文番号を表示させる部分は、注文詳細のテーブルが作成されてから変更する %>
+    <p class="title_text">注文番号：1234567890</p>
+  </div>
+
+  <div class="text-center my-5">
+    <button type="submit" class="btn btn-lg btn-primary">Topに戻る</button>
+  </div>
+</div>

--- a/app/views/static_pages/purchase_completed.html.erb
+++ b/app/views/static_pages/purchase_completed.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "購入完了") %>
 <div class="container">
 
   <div class="top_inner text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root 'static_pages#home'
+  get 'static_pages/purchase_completed', to: 'static_pages#purchase_completed', as: 'purchase_completed'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root 'static_pages#home'
-  get 'static_pages/purchase_completed', to: 'static_pages#purchase_completed', as: 'purchase_completed'
+  get '/purchase_completed', to: 'static_pages#purchase_completed', as: 'purchase_completed'
 end


### PR DESCRIPTION
## 作業内容

- フロント購入完了画面を実装
- provide, yieldメソッドを使い、タイトルを動的に変えられるようにする
- CSSを切り出して、custom.scss(他のコントローラで使いそうなCSSを置くファイル), static_page.scss(StaticPagesコントローラでしか使わないCSSを置くファイル)に分けて保存。
- app/assets/stylesheets/application.scssから、Topページに関わるCSSをstatic_page.scssに移動

## 対象ページ・箇所
Stylesheets:
app/assets/stylesheets/application.scss
app/assets/stylesheets/static_page.scss
app/assets/stylesheets/custom.scss

Controller: StaticPages
Action: purchase_completed
URL: /purchase_completed 

## 重点的に見てほしいところ(不安なところ)

- cusstom.scssに、そのままそれぞれのモックアップタスクのメディアクエリ(@media)を残しています。これを一緒にすると後から他の動的ページを実装する際にCSSがわかりづらくなると思って残していますが、これでいいでしょうか。

## 解決できなかった点