### PR TITLE
seedデータ作成、各モデル毎にdependent & optional オプション追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,9 +57,9 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
-    bcrypt (3.1.12)
     autoprefixer-rails (10.1.0.0)
       execjs
+    bcrypt (3.1.12)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  has_many :products
+  has_many :products, dependent: :nullify
 
   validates :category_name, presence: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,8 +1,8 @@
 class Product < ApplicationRecord
   belongs_to :user
-  belongs_to :category
-  belongs_to :sale_status
-  belongs_to :product_status
+  belongs_to :category, optional: true
+  belongs_to :sale_status, optional: true
+  belongs_to :product_status, optional: true
   has_many :purchases, dependent: :destroy
 
   validates :product_name, :price, presence: true

--- a/app/models/product_status.rb
+++ b/app/models/product_status.rb
@@ -1,5 +1,5 @@
 class ProductStatus < ApplicationRecord
-  has_many :products
+  has_many :products, dependent: :nullify
 
   validates :product_status_name, presence: true
 end

--- a/app/models/sale_status.rb
+++ b/app/models/sale_status.rb
@@ -1,5 +1,5 @@
 class SaleStatus < ApplicationRecord
-  has_many :products
+  has_many :products, dependent: :nullify
 
   validates :sale_status_name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   before_save { self.email = email.downcase }
-  belongs_to :user_classification
-  has_many :products
+  belongs_to :user_classification, optional: true
+  has_many :products, dependent: :destroy
   has_secure_password
   validates :password, presence: true, length: { in: 6..15 }, format: { with: /\A[a-z0-9]+\z/i }
   validates :last_name, :first_name, :municipality, presence: true, length: { maximum: 10 }

--- a/app/models/user_classification.rb
+++ b/app/models/user_classification.rb
@@ -1,5 +1,5 @@
 class UserClassification < ApplicationRecord
-  has_many :users
+  has_many :users, dependent: :nullify
 
   validates :user_classification_name, presence: true
 end

--- a/db/migrate/20201221042425_change_user_classification_id_to_users.rb
+++ b/db/migrate/20201221042425_change_user_classification_id_to_users.rb
@@ -1,0 +1,9 @@
+class ChangeUserClassificationIdToUsers < ActiveRecord::Migration[6.0]
+  def up
+    change_column :users, :user_classification_id, :bigint, null: true
+  end
+  
+  def down
+    change_column :users, :user_classification_id, :bigint, null: false
+  end
+end

--- a/db/migrate/20201221085428_change_references_id_to_products.rb
+++ b/db/migrate/20201221085428_change_references_id_to_products.rb
@@ -1,0 +1,13 @@
+class ChangeReferencesIdToProducts < ActiveRecord::Migration[6.0]
+  def up
+    change_column :products, :category_id, :bigint, null: true
+    change_column :products, :sale_status_id, :bigint, null: true
+    change_column :products, :product_status_id, :bigint, null: true
+  end
+  
+  def down
+    change_column :products, :category_id, :bigint, null: false
+    change_column :products, :sale_status_id, :bigint, null: false
+    change_column :products, :product_status_id, :bigint, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_15_073143) do
+ActiveRecord::Schema.define(version: 2020_12_21_085428) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "category_name", null: false
@@ -30,9 +30,9 @@ ActiveRecord::Schema.define(version: 2020_12_15_073143) do
     t.string "description"
     t.boolean "delete_flag", null: false
     t.bigint "user_id", null: false
-    t.bigint "category_id", null: false
-    t.bigint "sale_status_id", null: false
-    t.bigint "product_status_id", null: false
+    t.bigint "category_id"
+    t.bigint "sale_status_id"
+    t.bigint "product_status_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["category_id"], name: "index_products_on_category_id"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2020_12_15_073143) do
     t.string "apartments"
     t.string "email"
     t.string "phone_number"
-    t.bigint "user_classification_id", null: false
+    t.bigint "user_classification_id"
     t.string "company_name"
     t.boolean "delete_flag"
     t.datetime "created_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,22 +6,108 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-user_classification = UserClassification.create!(
-  user_classification_name: "会社員",
-)
+# ユーザー種別
+user_classification = UserClassification.create!(user_classification_name: "会社員")
 
-user_classification.users.create!(
-  last_name: "田中",
-  first_name: "太郎",
-  zipcode: 1234567,
-  prefecture: "兵庫県",
-  municipality: "神戸市",
-  address: "123456",
-  apartments: "apartment",
-  email: "tanakataro@example.com",
-  phone_number: "123456789012345",
-  company_name: "tanakacampany",
-  delete_flag: true,
-  password: "abc123",
-  password_confirmation: "abc123",
-)
+# ユーザー生成（1〜3）
+i = 1
+user_array = %w[田中 太郎 兵庫県 神戸市], %w[鈴木 一郎 広島県 広島市], %w[佐藤 二郎 愛知県 名古屋市]
+user_array.each do |first, second, third, fourth|
+  user_classification.users.create!(
+    last_name: first,
+    first_name: second,
+    zipcode: 1234567, # rubocop:disable Style/NumericLiterals
+    prefecture: third,
+    municipality: fourth,
+    address: "123456",
+    apartments: "apartment",
+    email: "user_#{i}@example.com",
+    phone_number: "09012345678",
+    company_name: "user#{i}_company",
+    delete_flag: false,
+    password: "#{i}#{i}#{i}#{i}#{i}#{i}",
+    password_confirmation: "#{i}#{i}#{i}#{i}#{i}#{i}",
+  )
+  i += 1
+end
+
+# カテゴリー
+cate_array = %w[PC関連 書籍]
+cate_array.each do |category|
+  Category.create!(category_name: category)
+end
+
+# 販売状況
+sale_st_array = %w[販売中 販売終了]
+sale_st_array.each do |sale_st|
+  SaleStatus.create!(sale_status_name: sale_st)
+end
+
+# 商品状態
+product_st_array = %w[新品 中古]
+product_st_array.each do |product_st|
+  ProductStatus.create!(product_status_name: product_st)
+end
+
+# ユーザー１が持つ商品：1〜2
+user1 = User.first
+product_array = %w[MacBookPro13インチ 154800 M1チップ搭載\s16GB\s256GB], %w[MacMini 132800 M1チップ搭載\s16Gb\s1TB]
+product_array.each do |first, second, third|
+  user1.products.create!(
+    product_name: first,
+    price: second,
+    description: third,
+    category_id: 1,
+    sale_status_id: 1,
+    product_status_id: 1,
+    delete_flag: false,
+  )
+end
+
+# ユーザー１が持つ商品の仕入：1〜2
+user1_products = user1.products
+i = user1_products.first.id
+# i = (user1.products.first).id
+purchase_array = %w[109000 10 AppleJapan株式会社], %w[93000 10 AppleJapan株式会社]
+purchase_array.each do |first, second, third|
+  user1.products.find(i).purchases.create!(
+    purchase_price: first,
+    purchase_quantity: second,
+    purchase_company: third,
+    order_date: Time.current,
+    purchase_date: Time.current,
+  )
+  i += 1
+end
+
+# ユーザー２が持つ商品：3〜4
+user2 = User.second
+product_array = %w[この一冊で全部わかるWeb技術の基本 1700 HTTP、データ形式からシステム開発まで。知識ゼロから全体像をつかめる。],
+                %w[基礎からのプログラミングリテラシー 2000 コンピュータのしくみから技術書の選び方まで厳選キーワードをくらべて学ぶ！]
+product_array.each do |first, second, third|
+  user2.products.create!(
+    product_name: first,
+    price: second,
+    description: third,
+    category_id: 2,
+    sale_status_id: 1,
+    product_status_id: 1,
+    delete_flag: false,
+  )
+end
+
+# ユーザー２が持つ商品の仕入：3〜4
+user2_products = user2.products
+i = user2_products.first.id
+# i = (user2.products.first).id
+purchase_array = %w[1000 5 SBクリエイティブ], %w[1200 5 技術評論社]
+purchase_array.each do |first, second, third|
+  user2.products.find(i).purchases.create!(
+    purchase_price: first,
+    purchase_quantity: second,
+    purchase_company: third,
+    order_date: Time.current,
+    purchase_date: Time.current,
+  )
+  i += 1
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,6 @@ end
 # ユーザー１が持つ商品の仕入：1〜2
 user1_products = user1.products
 i = user1_products.first.id
-# i = (user1.products.first).id
 purchase_array = %w[109000 10 AppleJapan株式会社], %w[93000 10 AppleJapan株式会社]
 purchase_array.each do |first, second, third|
   user1.products.find(i).purchases.create!(
@@ -99,7 +98,6 @@ end
 # ユーザー２が持つ商品の仕入：3〜4
 user2_products = user2.products
 i = user2_products.first.id
-# i = (user2.products.first).id
 purchase_array = %w[1000 5 SBクリエイティブ], %w[1200 5 技術評論社]
 purchase_array.each do |first, second, third|
   user2.products.find(i).purchases.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,8 +10,9 @@
 user_classification = UserClassification.create!(user_classification_name: "会社員")
 
 # ユーザー生成（1〜3）
-user_array = %w[田中 太郎 兵庫県 神戸市], %w[鈴木 一郎 愛知県 名古屋市], %w[佐藤 二郎 静岡県 静岡市]
-user_array.each.with_index(1) do |(first, second, third, fourth), i|
+[ 
+  %w[田中 太郎 兵庫県 神戸市], %w[鈴木 一郎 愛知県 名古屋市], %w[佐藤 二郎 静岡県 静岡市]
+].each.with_index(1) do |(first, second, third, fourth), i|
   user_classification.users.create!(
     last_name: first,
     first_name: second,
@@ -30,27 +31,25 @@ user_array.each.with_index(1) do |(first, second, third, fourth), i|
 end
 
 # カテゴリー
-cate_array = %w[PC関連 書籍]
-cate_array.each do
+%w[PC関連 書籍].each do
   Category.create!(category_name: _1)
 end
 
 # 販売状況
-sale_st_array = %w[販売中 販売終了]
-sale_st_array.each do
+%w[販売中 販売終了].each do
   SaleStatus.create!(sale_status_name: _1)
 end
 
 # 商品状態
-product_st_array = %w[新品 中古]
-product_st_array.each do
+%w[新品 中古].each do
   ProductStatus.create!(product_status_name: _1)
 end
 
 # ユーザー１が持つ商品：1〜2
 user1 = User.first
-product_array = %w[MacBookPro13インチ 154800 M1チップ搭載\ 16GB\ 256GB], %w[MacMini 132800 M1チップ搭載\ 16Gb\ 1TB]
-product_array.each do
+[
+  %w[MacBookPro13インチ 154800 M1チップ搭載\ 16GB\ 256GB], %w[MacMini 132800 M1チップ搭載\ 16Gb\ 1TB]
+].each do
   user1.products.create!(
     product_name: _1,
     price: _2,
@@ -63,8 +62,9 @@ product_array.each do
 end
 
 # ユーザー１が持つ商品の仕入：1〜2
-purchase_array = %w[109000 10 AppleJapan株式会社], %w[93000 10 AppleJapan株式会社]
-purchase_array.each.with_index(1) do |(first, second, third), i|
+[
+  %w[109000 10 AppleJapan株式会社], %w[93000 10 AppleJapan株式会社]
+].each.with_index(1) do |(first, second, third), i|
   user1.products.find(i).purchases.create!(
     purchase_price: first,
     purchase_quantity: second,
@@ -76,9 +76,10 @@ end
 
 # ユーザー２が持つ商品：3〜4
 user2 = User.second
-product_array = %w[この一冊で全部わかるWeb技術の基本 1700 HTTP、データ形式からシステム開発まで。知識ゼロから全体像をつかめる。],
-                %w[基礎からのプログラミングリテラシー 2000 コンピュータのしくみから技術書の選び方まで厳選キーワードをくらべて学ぶ！]
-product_array.each do
+[
+  %w[この一冊で全部わかるWeb技術の基本 1700 HTTP、データ形式からシステム開発まで。知識ゼロから全体像をつかめる。],
+  %w[基礎からのプログラミングリテラシー 2000 コンピュータのしくみから技術書の選び方まで厳選キーワードをくらべて学ぶ！]
+].each do
   user2.products.create!(
     product_name: _1,
     price: _2,
@@ -91,8 +92,9 @@ product_array.each do
 end
 
 # ユーザー２が持つ商品の仕入：3〜4
-purchase_array = %w[1000 5 SBクリエイティブ], %w[1200 5 技術評論社]
-purchase_array.each.with_index(3) do |(first, second, third), i|
+[
+  %w[1000 5 SBクリエイティブ], %w[1200 5 技術評論社]
+].each.with_index(3) do |(first, second, third), i|
   user2.products.find(i).purchases.create!(
     purchase_price: first,
     purchase_quantity: second,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,9 +10,8 @@
 user_classification = UserClassification.create!(user_classification_name: "会社員")
 
 # ユーザー生成（1〜3）
-i = 1
-user_array = %w[田中 太郎 兵庫県 神戸市], %w[鈴木 一郎 広島県 広島市], %w[佐藤 二郎 愛知県 名古屋市]
-user_array.each do |first, second, third, fourth|
+user_array = %w[田中 太郎 兵庫県 神戸市], %w[鈴木 一郎 愛知県 名古屋市], %w[佐藤 二郎 静岡県 静岡市]
+user_array.each.with_index(1) do |(first, second, third, fourth), i|
   user_classification.users.create!(
     last_name: first,
     first_name: second,
@@ -28,35 +27,34 @@ user_array.each do |first, second, third, fourth|
     password: "#{i}#{i}#{i}#{i}#{i}#{i}",
     password_confirmation: "#{i}#{i}#{i}#{i}#{i}#{i}",
   )
-  i += 1
 end
 
 # カテゴリー
 cate_array = %w[PC関連 書籍]
-cate_array.each do |category|
-  Category.create!(category_name: category)
+cate_array.each do
+  Category.create!(category_name: _1)
 end
 
 # 販売状況
 sale_st_array = %w[販売中 販売終了]
-sale_st_array.each do |sale_st|
-  SaleStatus.create!(sale_status_name: sale_st)
+sale_st_array.each do
+  SaleStatus.create!(sale_status_name: _1)
 end
 
 # 商品状態
 product_st_array = %w[新品 中古]
-product_st_array.each do |product_st|
-  ProductStatus.create!(product_status_name: product_st)
+product_st_array.each do
+  ProductStatus.create!(product_status_name: _1)
 end
 
 # ユーザー１が持つ商品：1〜2
 user1 = User.first
-product_array = %w[MacBookPro13インチ 154800 M1チップ搭載\s16GB\s256GB], %w[MacMini 132800 M1チップ搭載\s16Gb\s1TB]
-product_array.each do |first, second, third|
+product_array = %w[MacBookPro13インチ 154800 M1チップ搭載\ 16GB\ 256GB], %w[MacMini 132800 M1チップ搭載\ 16Gb\ 1TB]
+product_array.each do
   user1.products.create!(
-    product_name: first,
-    price: second,
-    description: third,
+    product_name: _1,
+    price: _2,
+    description: _3,
     category_id: 1,
     sale_status_id: 1,
     product_status_id: 1,
@@ -65,10 +63,8 @@ product_array.each do |first, second, third|
 end
 
 # ユーザー１が持つ商品の仕入：1〜2
-user1_products = user1.products
-i = user1_products.first.id
 purchase_array = %w[109000 10 AppleJapan株式会社], %w[93000 10 AppleJapan株式会社]
-purchase_array.each do |first, second, third|
+purchase_array.each.with_index(1) do |(first, second, third), i|
   user1.products.find(i).purchases.create!(
     purchase_price: first,
     purchase_quantity: second,
@@ -76,18 +72,17 @@ purchase_array.each do |first, second, third|
     order_date: Time.current,
     purchase_date: Time.current,
   )
-  i += 1
 end
 
 # ユーザー２が持つ商品：3〜4
 user2 = User.second
 product_array = %w[この一冊で全部わかるWeb技術の基本 1700 HTTP、データ形式からシステム開発まで。知識ゼロから全体像をつかめる。],
                 %w[基礎からのプログラミングリテラシー 2000 コンピュータのしくみから技術書の選び方まで厳選キーワードをくらべて学ぶ！]
-product_array.each do |first, second, third|
+product_array.each do
   user2.products.create!(
-    product_name: first,
-    price: second,
-    description: third,
+    product_name: _1,
+    price: _2,
+    description: _3,
     category_id: 2,
     sale_status_id: 1,
     product_status_id: 1,
@@ -96,10 +91,8 @@ product_array.each do |first, second, third|
 end
 
 # ユーザー２が持つ商品の仕入：3〜4
-user2_products = user2.products
-i = user2_products.first.id
 purchase_array = %w[1000 5 SBクリエイティブ], %w[1200 5 技術評論社]
-purchase_array.each do |first, second, third|
+purchase_array.each.with_index(3) do |(first, second, third), i|
   user2.products.find(i).purchases.create!(
     purchase_price: first,
     purchase_quantity: second,
@@ -107,5 +100,4 @@ purchase_array.each do |first, second, third|
     order_date: Time.current,
     purchase_date: Time.current,
   )
-  i += 1
 end


### PR DESCRIPTION
## 作業内容
- zipcodeの警告：rubocop: disableのコメントを書き警告を出ないようにした。
- 親要素が消えても子要素を消さないよう、dependent: :nullify オプションを設定。
- 親要素を消した後、残った子要素が持つ外部キーをnilで更新されるようbelongs_to にoptional: trueを設定。

- また、Product関連のデータも生成するようseedへ追記しました。
　※ユーザ３人、商品情報は２人に２品（計4品）を登録

## 対象ページ・箇所

## 重点的に見てほしいところ(不安なところ)

## 解決できなかった点
以下の手順でoptional: trueが効いているかrails consoleから確認したのですが、
Mysqlのエラーが出て、外部キーnilでの更新や新規登録が行えませんでした。

> ①optional: trueを設定したユーザ種別、ユーザ生成
> ②親要素であるユーザ種別を削除(destroy_all)・・・しようとしたところMysqlのエラーが表示
> ③また、外部キーnilでUser.createを実行してもMysqlのエラーが表示

対処方法を調べてみたのですが、参考になる情報がなかなか得られなかったです。
考えてみた対策として、対策必要なモデルの各外部キーがnull: falseとなっているのをnull: trueにすればいけそうな気がしております。
調べてみると以下のような記事が見つかりました。対処法にお間違い無ければモデル修正を行いますがいかがでしょうか。
https://stackoverflow.com/questions/56347603/rails-6-foreign-key-cant-be-null